### PR TITLE
Fix resource leak after API call.

### DIFF
--- a/parse.go
+++ b/parse.go
@@ -273,7 +273,7 @@ func (c *Client) Do(req *http.Request, body, result interface{}) (*http.Response
 	}
 
 	res, err := c.RoundTrip(req)
-	if res.Body != nil {
+	if res != nil && res.Body != nil {
 		defer res.Body.Close()
 	}
 	if err != nil {

--- a/parse.go
+++ b/parse.go
@@ -273,10 +273,12 @@ func (c *Client) Do(req *http.Request, body, result interface{}) (*http.Response
 	}
 
 	res, err := c.RoundTrip(req)
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
 	if err != nil {
 		return res, err
 	}
-	defer res.Body.Close()
 
 	if result != nil {
 		if err := json.NewDecoder(res.Body).Decode(result); err != nil {


### PR DESCRIPTION
Ensure response body is always closed.

This fixes an issue that manifested itself as an ever increasing number of goroutines in long-running processes using this API.
